### PR TITLE
feat/messages

### DIFF
--- a/lib/core/app/app.dart
+++ b/lib/core/app/app.dart
@@ -8,7 +8,8 @@ import '../../features/features.dart';
     AdaptiveRoute(page: SplashView, initial: true),
     AdaptiveRoute(page: SettingsView),
     AdaptiveRoute(page: ChatView),
-    AdaptiveRoute(page: WrapperView)
+    AdaptiveRoute(page: WrapperView),
+    AdaptiveRoute(page: MessagesView),
   ],
   dependencies: [
     LazySingleton(classType: NavigationService),

--- a/lib/core/app/app.router.dart
+++ b/lib/core/app/app.router.dart
@@ -19,11 +19,14 @@ class Routes {
 
   static const wrapperView = '/wrapper-view';
 
+  static const messagesView = '/messages-view';
+
   static const all = <String>{
     splashView,
     settingsView,
     chatView,
     wrapperView,
+    messagesView,
   };
 }
 
@@ -44,6 +47,10 @@ class StackedRouter extends _i1.RouterBase {
     _i1.RouteDef(
       Routes.wrapperView,
       page: _i2.WrapperView,
+    ),
+    _i1.RouteDef(
+      Routes.messagesView,
+      page: _i2.MessagesView,
     ),
   ];
 
@@ -69,6 +76,12 @@ class StackedRouter extends _i1.RouterBase {
     _i2.WrapperView: (data) {
       return _i1.buildAdaptivePageRoute<dynamic>(
         builder: (context) => const _i2.WrapperView(),
+        settings: data,
+      );
+    },
+    _i2.MessagesView: (data) {
+      return _i1.buildAdaptivePageRoute<dynamic>(
+        builder: (context) => const _i2.MessagesView(),
         settings: data,
       );
     },
@@ -131,6 +144,20 @@ extension NavigatorStateExtension on _i3.NavigationService {
         transition,
   ]) async {
     return navigateTo<dynamic>(Routes.wrapperView,
+        id: routerId,
+        preventDuplicates: preventDuplicates,
+        parameters: parameters,
+        transition: transition);
+  }
+
+  Future<dynamic> navigateToMessagesView([
+    int? routerId,
+    bool preventDuplicates = true,
+    Map<String, String>? parameters,
+    Widget Function(BuildContext, Animation<double>, Animation<double>, Widget)?
+        transition,
+  ]) async {
+    return navigateTo<dynamic>(Routes.messagesView,
         id: routerId,
         preventDuplicates: preventDuplicates,
         parameters: parameters,

--- a/lib/core/shared_widgets/custom_avatar.dart
+++ b/lib/core/shared_widgets/custom_avatar.dart
@@ -2,10 +2,10 @@ import 'package:flutter/material.dart';
 
 import '../utils/utils.dart';
 
-class MessageAvatar extends StatelessWidget {
+class CustomAvatar extends StatelessWidget {
   final String image;
   final String initials;
-  const MessageAvatar({
+  const CustomAvatar({
     super.key,
     required this.image,
     required this.initials,

--- a/lib/core/shared_widgets/message_tile.dart
+++ b/lib/core/shared_widgets/message_tile.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 
 import '../utils/utils.dart';
-import 'message_avatar.dart';
+import 'custom_avatar.dart';
 
 class MessageTile extends StatelessWidget {
   final String image;
@@ -10,6 +10,7 @@ class MessageTile extends StatelessWidget {
   final String lastMessage;
   final String time;
   final VoidCallback onTap;
+  final bool isSelected;
   const MessageTile({
     super.key,
     required this.image,
@@ -18,41 +19,45 @@ class MessageTile extends StatelessWidget {
     required this.lastMessage,
     required this.time,
     required this.onTap,
+    this.isSelected = false,
   });
 
   @override
   Widget build(BuildContext context) {
     SizeMg.init(context);
-    return ListTile(
-      leading: MessageAvatar(
-        image: image,
-        initials: initials,
-      ),
-      title: Text(
-        name,
-        style: TextStyle(
-          color: Palette.white,
-          fontWeight: FontWeight.w400,
-          fontSize: SizeMg.text(15),
+    return Container(
+      color: isSelected ? Palette.gray : Palette.transparent,
+      child: ListTile(
+        leading: CustomAvatar(
+          image: image,
+          initials: initials,
         ),
-      ),
-      subtitle: Text(
-        lastMessage,
-        style: TextStyle(
-          color: Palette.white,
-          fontWeight: FontWeight.w300,
-          fontSize: SizeMg.text(13),
+        title: Text(
+          name,
+          style: TextStyle(
+            color: Palette.white,
+            fontWeight: FontWeight.w400,
+            fontSize: SizeMg.text(15),
+          ),
         ),
-      ),
-      trailing: Text(
-        time,
-        style: TextStyle(
-          color: Palette.white,
-          fontWeight: FontWeight.w400,
-          fontSize: SizeMg.text(15),
+        subtitle: Text(
+          lastMessage,
+          style: TextStyle(
+            color: Palette.white,
+            fontWeight: FontWeight.w300,
+            fontSize: SizeMg.text(13),
+          ),
         ),
+        trailing: Text(
+          time,
+          style: TextStyle(
+            color: Palette.white,
+            fontWeight: FontWeight.w400,
+            fontSize: SizeMg.text(15),
+          ),
+        ),
+        onTap: onTap,
       ),
-      onTap: onTap,
     );
   }
 }

--- a/lib/core/shared_widgets/shared_widgets.dart
+++ b/lib/core/shared_widgets/shared_widgets.dart
@@ -1,5 +1,5 @@
 export 'story_bubble.dart';
 export 'custom_icon_button.dart';
 export 'message_tile.dart';
-export 'message_avatar.dart';
+export 'custom_avatar.dart';
 export 'custom_textfield.dart';

--- a/lib/core/utils/context_util.dart
+++ b/lib/core/utils/context_util.dart
@@ -1,0 +1,16 @@
+import 'package:flutter/widgets.dart';
+
+class ContextUtil {
+  /// Hides keyboard by finding the primary focused [FocusNode] or
+  /// [FocusScopeNode] then unfocusing it. Take note that this triggers
+  /// [State.didChangeDependencies] on specific UIs which holds the node.
+  ///
+  /// The context parameter is additional layer of check to ensure it is not
+  /// calling FocusManager on places where context does not exist such as
+  /// tests.
+  static void hideKeyboard(context) {
+    if (context == null) return;
+
+    FocusManager.instance.primaryFocus?.unfocus();
+  }
+}

--- a/lib/core/utils/palette.dart
+++ b/lib/core/utils/palette.dart
@@ -2,8 +2,13 @@ import 'package:flutter/material.dart';
 
 class Palette {
   static const gray = Color(0xff565E70);
+  static const grayTunedDeep = Color(0xff373E4E);
+  static const grayTunedLight = Color(0xffC4C4C4);
   static const blue = Color(0xff03A9F1);
+  static const green = Color(0xff00AC83);
   static const scaffoldColor = Color(0xff292F3F);
+  static const meMessageBubbleColor = Color(0xff272A35);
+  static const notMeMessageBubbleColor = Color(0xff373E4E);
   static const textFieldFilledRGBA = Color.fromARGB(0, 25, 0, 0);
   static const white = Colors.white;
   static const yellow = Colors.yellow;

--- a/lib/core/utils/utils.dart
+++ b/lib/core/utils/utils.dart
@@ -1,3 +1,4 @@
 export 'size_manager.dart';
 export 'palette.dart';
 export 'string_util.dart';
+export 'context_util.dart';

--- a/lib/features/chat/chat_view.dart
+++ b/lib/features/chat/chat_view.dart
@@ -8,10 +8,10 @@ class ChatView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return ScreenTypeLayout.builder(
-      mobile: (context) => const ChatMobileView(),
-      tablet: (context) => const ChatTabletView(),
-      desktop: (context) => const ChatDesktopView(),
+    return ScreenTypeLayout(
+      mobile: const ChatMobileView(),
+      tablet: ChatTabletView(),
+      desktop: ChatDesktopView(),
     );
   }
 }

--- a/lib/features/chat/screen_type/desktop/chat_desktop_view.dart
+++ b/lib/features/chat/screen_type/desktop/chat_desktop_view.dart
@@ -3,10 +3,14 @@ import 'package:flutter/material.dart';
 import 'package:stacked/stacked.dart';
 
 import '../../../../core/core.dart';
+import '../../../messages/screen_type/messages_screen_type.dart';
 import '../../view_model/chat_viewmodel.dart';
 
+// ignore: must_be_immutable
 class ChatDesktopView extends StatelessWidget {
-  const ChatDesktopView({Key? key}) : super(key: key);
+  ChatDesktopView({Key? key}) : super(key: key);
+
+  int? selectedIndex = -1;
 
   @override
   Widget build(BuildContext context) {
@@ -101,21 +105,33 @@ class ChatDesktopView extends StatelessWidget {
                       name: 'Michael Kalango',
                       lastMessage: 'Let\'s keep cooking',
                       time: 'Tue',
-                      onTap: () {},
+                      isSelected: selectedIndex == index,
+                      onTap: () {
+                        selectedIndex = index;
+                        model.notifyListeners();
+                      },
                     );
                   },
                 ),
               ],
             ),
-            endPane: Center(
-              child: Text(
-                'Message Detail View',
-                style: TextStyle(
-                  color: Palette.white,
-                  fontSize: SizeMg.text(20),
-                  fontWeight: FontWeight.w400,
-                ),
-              ),
+            endPane: Builder(
+              builder: (context) {
+                if (selectedIndex == -1) {
+                  return Center(
+                    child: Text(
+                      'No Message(s) selected',
+                      style: TextStyle(
+                        color: Palette.white,
+                        fontSize: SizeMg.text(20),
+                        fontWeight: FontWeight.w400,
+                      ),
+                    ),
+                  );
+                }
+
+                return const MessagesDesktopView();
+              },
             ),
           ),
         );

--- a/lib/features/chat/screen_type/mobile/chat_mobile_view.dart
+++ b/lib/features/chat/screen_type/mobile/chat_mobile_view.dart
@@ -98,7 +98,7 @@ class ChatMobileView extends StatelessWidget {
                     name: 'Michael Kalango',
                     lastMessage: 'Let\'s keep cooking',
                     time: 'Tue',
-                    onTap: () {},
+                    onTap: model.actionMoveToMessages,
                   );
                 },
               ),

--- a/lib/features/chat/screen_type/tablet/chat_tablet_view.dart
+++ b/lib/features/chat/screen_type/tablet/chat_tablet_view.dart
@@ -1,12 +1,16 @@
 import 'package:dual_screen/dual_screen.dart';
 import 'package:flutter/material.dart';
+import 'package:responsive_chat_ui/features/messages/screen_type/messages_screen_type.dart';
 import 'package:stacked/stacked.dart';
 
 import '../../../../core/core.dart';
 import '../../view_model/chat_viewmodel.dart';
 
+// ignore: must_be_immutable
 class ChatTabletView extends StatelessWidget {
-  const ChatTabletView({Key? key}) : super(key: key);
+  ChatTabletView({Key? key}) : super(key: key);
+
+  int? selectedIndex = -1;
 
   @override
   Widget build(BuildContext context) {
@@ -101,21 +105,33 @@ class ChatTabletView extends StatelessWidget {
                       name: 'Michael Kalango',
                       lastMessage: 'Let\'s keep cooking',
                       time: 'Tue',
-                      onTap: () {},
+                      isSelected: selectedIndex == index,
+                      onTap: () {
+                        selectedIndex = index;
+                        model.notifyListeners();
+                      },
                     );
                   },
                 ),
               ],
             ),
-            endPane: Center(
-              child: Text(
-                'Message Detail View',
-                style: TextStyle(
-                  color: Palette.white,
-                  fontSize: SizeMg.text(20),
-                  fontWeight: FontWeight.w400,
-                ),
-              ),
+            endPane: Builder(
+              builder: (context) {
+                if (selectedIndex == -1) {
+                  return Center(
+                    child: Text(
+                      'No Message(s) selected',
+                      style: TextStyle(
+                        color: Palette.white,
+                        fontSize: SizeMg.text(20),
+                        fontWeight: FontWeight.w400,
+                      ),
+                    ),
+                  );
+                }
+
+                return const MessagesTabletView();
+              },
             ),
           ),
         );

--- a/lib/features/chat/view_model/chat_viewmodel.dart
+++ b/lib/features/chat/view_model/chat_viewmodel.dart
@@ -1,3 +1,12 @@
 import 'package:stacked/stacked.dart';
+import 'package:stacked_services/stacked_services.dart';
 
-class ChatViewModel extends BaseViewModel {}
+import '../../../core/core.dart';
+
+class ChatViewModel extends BaseViewModel {
+  final _navigationService = locator<NavigationService>();
+
+  void actionMoveToMessages() {
+    _navigationService.navigateToMessagesView();
+  }
+}

--- a/lib/features/features.dart
+++ b/lib/features/features.dart
@@ -2,3 +2,4 @@ export 'chat/chat_view.dart';
 export 'settings/settings_view.dart';
 export 'splash/splash_view.dart';
 export 'wrapper/wrapper_view.dart';
+export 'messages/messages_view.dart';

--- a/lib/features/messages/messages_view.dart
+++ b/lib/features/messages/messages_view.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+import 'package:responsive_builder/responsive_builder.dart';
+
+import 'screen_type/messages_screen_type.dart';
+
+class MessagesView extends StatelessWidget {
+  const MessagesView({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return ScreenTypeLayout(
+      mobile: const MessagesMobileView(),
+      tablet: const MessagesTabletView(),
+      desktop: const MessagesDesktopView(),
+    );
+  }
+}

--- a/lib/features/messages/screen_type/desktop/mesages_desktop_view.dart
+++ b/lib/features/messages/screen_type/desktop/mesages_desktop_view.dart
@@ -1,0 +1,137 @@
+import 'package:flutter/material.dart';
+import 'package:responsive_chat_ui/core/core.dart';
+import 'package:stacked/stacked.dart';
+
+import '../../view_model/messages_viewmodel.dart';
+import '../../widgets/message_bubble.dart';
+
+class MessagesDesktopView extends StatelessWidget {
+  const MessagesDesktopView({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    SizeMg.init(context);
+    return ViewModelBuilder<MessagesViewModel>.reactive(
+      viewModelBuilder: () => MessagesViewModel(),
+      builder: (
+        BuildContext context,
+        MessagesViewModel model,
+        Widget? child,
+      ) {
+        return GestureDetector(
+          onTap: () => ContextUtil.hideKeyboard(context),
+          child: Scaffold(
+            backgroundColor: Palette.scaffoldColor,
+            appBar: AppBar(
+              elevation: 0,
+              backgroundColor: Palette.transparent,
+              leading: const CustomAvatar(
+                image: '',
+                initials: 'MK',
+              ),
+              title: Text(
+                'Michael Kalango',
+                style: TextStyle(
+                  color: Palette.white,
+                  fontWeight: FontWeight.w400,
+                  fontSize: SizeMg.text(15),
+                ),
+              ),
+            ),
+            body: Column(
+              children: [
+                Expanded(
+                  child: ListView(
+                    reverse: true,
+                    padding: EdgeInsets.only(
+                      bottom: SizeMg.height(10),
+                      left: SizeMg.width(10),
+                      right: SizeMg.width(10),
+                    ),
+                    children: [
+                      const MessageBubble(
+                        message: 'Hahaa.. I get you.',
+                        percentile: 7,
+                      ),
+                      SizedBox(
+                        height: SizeMg.height(15),
+                      ),
+                      const MessageBubble(
+                        message:
+                            'I have been better. Just the New Year vibes hasn\'t sunk in yet you know.',
+                        isMe: true,
+                        percentile: 7,
+                      ),
+                      SizedBox(
+                        height: SizeMg.height(15),
+                      ),
+                      const MessageBubble(
+                        message: 'I am fine and you?',
+                        percentile: 7,
+                      ),
+                      SizedBox(
+                        height: SizeMg.height(15),
+                      ),
+                      const MessageBubble(
+                        message: 'Hi, How are you?',
+                        isMe: true,
+                        percentile: 7,
+                      ),
+                      SizedBox(
+                        height: SizeMg.height(15),
+                      ),
+                      const MessageBubble(
+                        message: 'Hello',
+                        percentile: 7,
+                      ),
+                    ],
+                  ),
+                ),
+                Padding(
+                  padding: EdgeInsets.only(
+                    top: SizeMg.height(5),
+                    left: SizeMg.width(10),
+                    right: SizeMg.width(10),
+                    bottom: SizeMg.height(20),
+                  ),
+                  child: Row(
+                    children: [
+                      const Expanded(
+                        flex: 2,
+                        child: CustomTextField(
+                          hintText: 'write',
+                        ),
+                      ),
+                      SizedBox(
+                        width: SizeMg.width(5),
+                      ),
+                      CustomIconButton(
+                        icon: const Icon(
+                          Icons.chat_bubble_rounded,
+                          color: Palette.grayTunedLight,
+                        ),
+                        color: Palette.grayTunedDeep,
+                        onTap: () {},
+                      ),
+                      SizedBox(
+                        width: SizeMg.width(5),
+                      ),
+                      CustomIconButton(
+                        icon: const Icon(
+                          Icons.camera_alt,
+                          color: Palette.white,
+                        ),
+                        color: Palette.green,
+                        onTap: () {},
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/lib/features/messages/screen_type/messages_screen_type.dart
+++ b/lib/features/messages/screen_type/messages_screen_type.dart
@@ -1,0 +1,3 @@
+export 'desktop/mesages_desktop_view.dart';
+export 'mobile/messages_mobile_view.dart';
+export 'tablet/messages_tablet_view.dart';

--- a/lib/features/messages/screen_type/mobile/messages_mobile_view.dart
+++ b/lib/features/messages/screen_type/mobile/messages_mobile_view.dart
@@ -1,0 +1,150 @@
+import 'package:flutter/material.dart';
+import 'package:stacked/stacked.dart';
+
+import '../../../../core/core.dart';
+import '../../view_model/messages_viewmodel.dart';
+import '../../widgets/message_bubble.dart';
+
+class MessagesMobileView extends StatelessWidget {
+  const MessagesMobileView({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    SizeMg.init(context);
+    return ViewModelBuilder<MessagesViewModel>.reactive(
+      viewModelBuilder: () => MessagesViewModel(),
+      builder: (
+        BuildContext context,
+        MessagesViewModel model,
+        Widget? child,
+      ) {
+        return GestureDetector(
+          onTap: () => ContextUtil.hideKeyboard(context),
+          child: Scaffold(
+            backgroundColor: Palette.scaffoldColor,
+            appBar: AppBar(
+              backgroundColor: Palette.transparent,
+              elevation: 0,
+              title: Row(
+                mainAxisAlignment: MainAxisAlignment.spaceAround,
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  const CustomAvatar(
+                    image: '',
+                    initials: 'MK',
+                  ),
+                  SizedBox(
+                    width: SizeMg.width(5),
+                  ),
+                  Text(
+                    'Michael Kalango',
+                    style: TextStyle(
+                      color: Palette.white,
+                      fontWeight: FontWeight.w400,
+                      fontSize: SizeMg.text(15),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            body: Column(
+              children: [
+                Expanded(
+                  child: ListView(
+                    reverse: true,
+                    padding: EdgeInsets.only(
+                      bottom: SizeMg.height(10),
+                      left: SizeMg.width(10),
+                      right: SizeMg.width(10),
+                    ),
+                    children: [
+                      const MessageBubble(
+                        message: 'Hahaa.. I get you.',
+                        percentile: 2,
+                      ),
+                      SizedBox(
+                        height: SizeMg.height(15),
+                      ),
+                      const MessageBubble(
+                        message:
+                            'I have been better. Just the New Year vibes hasn\'t sunk in yet you know.',
+                        isMe: true,
+                        percentile: 2,
+                      ),
+                      SizedBox(
+                        height: SizeMg.height(15),
+                      ),
+                      const MessageBubble(
+                        message: 'I am fine and you?',
+                        percentile: 2,
+                      ),
+                      SizedBox(
+                        height: SizeMg.height(15),
+                      ),
+                      const MessageBubble(
+                        message: 'Hi, How are you?',
+                        isMe: true,
+                        percentile: 2,
+                      ),
+                      SizedBox(
+                        height: SizeMg.height(15),
+                      ),
+                      const MessageBubble(
+                        message: 'Hello',
+                        percentile: 2,
+                      ),
+                    ],
+                  ),
+                ),
+                Padding(
+                  padding: EdgeInsets.only(
+                    top: SizeMg.height(5),
+                    left: SizeMg.width(10),
+                    right: SizeMg.width(10),
+                    bottom: SizeMg.height(20),
+                  ),
+                  child: Row(
+                    children: [
+                      const Expanded(
+                        flex: 2,
+                        child: CustomTextField(
+                          hintText: 'write',
+                        ),
+                      ),
+                      SizedBox(
+                        width: SizeMg.width(5),
+                      ),
+                      Expanded(
+                        child: Row(
+                          mainAxisAlignment: MainAxisAlignment.spaceAround,
+                          children: [
+                            CustomIconButton(
+                              icon: const Icon(
+                                Icons.chat_bubble_rounded,
+                                color: Palette.grayTunedLight,
+                              ),
+                              color: Palette.grayTunedDeep,
+                              onTap: () {},
+                            ),
+                            CustomIconButton(
+                              icon: const Icon(
+                                Icons.camera_alt,
+                                color: Palette.white,
+                              ),
+                              color: Palette.green,
+                              onTap: () {},
+                            ),
+                          ],
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/lib/features/messages/screen_type/tablet/messages_tablet_view.dart
+++ b/lib/features/messages/screen_type/tablet/messages_tablet_view.dart
@@ -1,0 +1,140 @@
+import 'package:flutter/material.dart';
+import 'package:stacked/stacked.dart';
+
+import '../../../../core/core.dart';
+import '../../view_model/messages_viewmodel.dart';
+import '../../widgets/message_bubble.dart';
+
+class MessagesTabletView extends StatelessWidget {
+  const MessagesTabletView({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return ViewModelBuilder<MessagesViewModel>.reactive(
+      viewModelBuilder: () => MessagesViewModel(),
+      builder: (
+        BuildContext context,
+        MessagesViewModel model,
+        Widget? child,
+      ) {
+        return GestureDetector(
+          onTap: () => ContextUtil.hideKeyboard(context),
+          child: Scaffold(
+            backgroundColor: Palette.scaffoldColor,
+            appBar: AppBar(
+              elevation: 0,
+              backgroundColor: Palette.transparent,
+              leading: const CustomAvatar(
+                image: '',
+                initials: 'MK',
+              ),
+              title: Text(
+                'Michael Kalango',
+                style: TextStyle(
+                  color: Palette.white,
+                  fontWeight: FontWeight.w400,
+                  fontSize: SizeMg.text(15),
+                ),
+              ),
+            ),
+            body: Column(
+              children: [
+                Expanded(
+                  child: ListView(
+                    reverse: true,
+                    padding: EdgeInsets.only(
+                      bottom: SizeMg.height(10),
+                      left: SizeMg.width(10),
+                      right: SizeMg.width(10),
+                    ),
+                    children: [
+                      const MessageBubble(
+                        message: 'Hahaa.. I get you.',
+                        percentile: 5,
+                      ),
+                      SizedBox(
+                        height: SizeMg.height(15),
+                      ),
+                      const MessageBubble(
+                        message:
+                            'I have been better. Just the New Year vibes hasn\'t sunk in yet you know.',
+                        isMe: true,
+                        percentile: 5,
+                      ),
+                      SizedBox(
+                        height: SizeMg.height(15),
+                      ),
+                      const MessageBubble(
+                        message: 'I am fine and you?',
+                        percentile: 5,
+                      ),
+                      SizedBox(
+                        height: SizeMg.height(15),
+                      ),
+                      const MessageBubble(
+                        message: 'Hi, How are you?',
+                        isMe: true,
+                        percentile: 5,
+                      ),
+                      SizedBox(
+                        height: SizeMg.height(15),
+                      ),
+                      const MessageBubble(
+                        message: 'Hello',
+                        percentile: 5,
+                      ),
+                    ],
+                  ),
+                ),
+                Padding(
+                  padding: EdgeInsets.only(
+                    top: SizeMg.height(5),
+                    left: SizeMg.width(10),
+                    right: SizeMg.width(10),
+                    bottom: SizeMg.height(20),
+                  ),
+                  child: Row(
+                    children: [
+                      const Expanded(
+                        flex: 2,
+                        child: CustomTextField(
+                          hintText: 'write',
+                        ),
+                      ),
+                      SizedBox(
+                        width: SizeMg.width(10),
+                      ),
+                      Expanded(
+                        child: Row(
+                          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                          children: [
+                            CustomIconButton(
+                              icon: const Icon(
+                                Icons.chat_bubble_rounded,
+                                color: Palette.grayTunedLight,
+                              ),
+                              color: Palette.grayTunedDeep,
+                              onTap: () {},
+                            ),
+                            CustomIconButton(
+                              icon: const Icon(
+                                Icons.camera_alt,
+                                color: Palette.white,
+                              ),
+                              color: Palette.green,
+                              onTap: () {},
+                            ),
+                          ],
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/lib/features/messages/view_model/messages_viewmodel.dart
+++ b/lib/features/messages/view_model/messages_viewmodel.dart
@@ -1,0 +1,3 @@
+import 'package:stacked/stacked.dart';
+
+class MessagesViewModel extends BaseViewModel {}

--- a/lib/features/messages/widgets/message_bubble.dart
+++ b/lib/features/messages/widgets/message_bubble.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/material.dart';
+
+import '../../../core/core.dart';
+
+class MessageBubble extends StatelessWidget {
+  final bool isMe;
+  final String message;
+  final double percentile;
+  const MessageBubble({
+    super.key,
+    this.isMe = false,
+    required this.message,
+    required this.percentile,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    SizeMg.init(context);
+    return Align(
+      alignment: isMe ? Alignment.bottomRight : Alignment.bottomLeft,
+      child: Container(
+        width: SizeMg.screenWidth / percentile,
+        padding: const EdgeInsets.all(8),
+        decoration: BoxDecoration(
+          color: isMe
+              ? Palette.meMessageBubbleColor
+              : Palette.notMeMessageBubbleColor,
+          borderRadius: BorderRadius.circular(SizeMg.radius(20)),
+        ),
+        child: Text(
+          message,
+          textAlign: isMe ? TextAlign.end : TextAlign.start,
+          style: TextStyle(
+            fontWeight: FontWeight.w300,
+            fontSize: SizeMg.text(13),
+            color: Palette.white,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/settings/settings_view.dart
+++ b/lib/features/settings/settings_view.dart
@@ -8,10 +8,10 @@ class SettingsView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return ScreenTypeLayout.builder(
-      mobile: (context) => const SettingsMobileView(),
-      tablet: (context) => const SettingsTabletView(),
-      desktop: (context) => const SettingsDesktopView(),
+    return ScreenTypeLayout(
+      mobile: const SettingsMobileView(),
+      tablet: const SettingsTabletView(),
+      desktop: const SettingsDesktopView(),
     );
   }
 }

--- a/lib/features/splash/splash_view.dart
+++ b/lib/features/splash/splash_view.dart
@@ -8,10 +8,10 @@ class SplashView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return ScreenTypeLayout.builder(
-      mobile: (context) => const SplashMobileView(),
-      tablet: (context) => const SplashTabletView(),
-      desktop: (context) => const SplashDesktopView(),
+    return ScreenTypeLayout(
+      mobile: const SplashMobileView(),
+      tablet: const SplashTabletView(),
+      desktop: const SplashDesktopView(),
     );
   }
 }

--- a/lib/features/wrapper/wrapper_view.dart
+++ b/lib/features/wrapper/wrapper_view.dart
@@ -8,10 +8,10 @@ class WrapperView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return ScreenTypeLayout.builder(
-      mobile: (context) => const WrapperMobileView(),
-      tablet: (context) => const WrapperTabletView(),
-      desktop: (context) => const WrapperDesktopView(),
+    return ScreenTypeLayout(
+      mobile: const WrapperMobileView(),
+      tablet: const WrapperTabletView(),
+      desktop: const WrapperDesktopView(),
     );
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,14 +7,14 @@ packages:
       name: _fe_analyzer_shared
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "49.0.0"
+    version: "50.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.1.0"
+    version: "5.2.0"
   args:
     dependency: transitive
     description:
@@ -63,21 +63,21 @@ packages:
       name: build_resolvers
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.10"
+    version: "2.1.0"
   build_runner:
     dependency: "direct dev"
     description:
       name: build_runner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.3.2"
+    version: "2.3.3"
   build_runner_core:
     dependency: transitive
     description:
       name: build_runner_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "7.2.6"
+    version: "7.2.7"
   built_collection:
     dependency: transitive
     description:
@@ -91,7 +91,7 @@ packages:
       name: built_value
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "8.4.1"
+    version: "8.4.2"
   characters:
     dependency: transitive
     description:
@@ -119,7 +119,7 @@ packages:
       name: code_builder
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.3.0"
+    version: "4.4.0"
   collection:
     dependency: transitive
     description:
@@ -213,7 +213,7 @@ packages:
       name: flutter_screenutil
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.5.4"
+    version: "5.6.0"
   flutter_statusbarcolor_ns:
     dependency: transitive
     description:
@@ -237,7 +237,7 @@ packages:
       name: frontend_server_client
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.0"
+    version: "3.2.0"
   get:
     dependency: transitive
     description:
@@ -258,14 +258,14 @@ packages:
       name: glob
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   graphs:
     dependency: transitive
     description:
       name: graphs
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.2.0"
   http_multi_server:
     dependency: transitive
     description:
@@ -314,7 +314,7 @@ packages:
       name: lints
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.0.1"
   logger:
     dependency: "direct main"
     description:
@@ -356,7 +356,7 @@ packages:
       name: mime
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.2"
+    version: "1.0.3"
   nested:
     dependency: transitive
     description:
@@ -433,14 +433,14 @@ packages:
       name: provider
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.0.4"
+    version: "6.0.5"
   pub_semver:
     dependency: transitive
     description:
       name: pub_semver
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.3"
   pubspec_parse:
     dependency: transitive
     description:
@@ -468,7 +468,7 @@ packages:
       name: rxdart
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.27.5"
+    version: "0.27.7"
   shared_preferences:
     dependency: transitive
     description:
@@ -496,7 +496,7 @@ packages:
       name: shared_preferences_linux
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   shared_preferences_macos:
     dependency: transitive
     description:
@@ -524,7 +524,7 @@ packages:
       name: shared_preferences_windows
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   shelf:
     dependency: transitive
     description:
@@ -538,7 +538,7 @@ packages:
       name: shelf_web_socket
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.2"
+    version: "1.0.3"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -571,7 +571,7 @@ packages:
       name: stacked
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.0"
+    version: "3.0.1"
   stacked_core:
     dependency: transitive
     description:
@@ -585,14 +585,14 @@ packages:
       name: stacked_generator
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.8.0+1"
+    version: "0.8.1"
   stacked_services:
     dependency: "direct main"
     description:
       name: stacked_services
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.9.5"
+    version: "0.9.8"
   stacked_themes:
     dependency: "direct main"
     description:
@@ -613,7 +613,7 @@ packages:
       name: stream_transform
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.1"
+    version: "2.1.0"
   string_scanner:
     dependency: transitive
     description:
@@ -683,7 +683,7 @@ packages:
       name: win32
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.1"
+    version: "3.1.3"
   xdg_directories:
     dependency: transitive
     description:


### PR DESCRIPTION
**This PR includes:**

- Changed the `ScreenTypeLayout` from a `builder` logic to a plain `constructor`. This is to mitigate the rebuilding of the UI when it transitions between the `Mobile`, `Tablet`, and `Desktop/Web` view.
- Created the `Messages` feature and added it to the project. Made the decision of handling how this feature works based on the `ScreenType` being rendered.
- Created the `MessageBubble` reusable widget that is used across the messages feature.
- Renamed the avatar widget to allow for usage where needed without causing meaning conflicts.
- Created a `ContextUtil` to help with keyboard dismissing when a section of the screen is tapped.